### PR TITLE
Potential fix for code scanning alert no. 12: Potentially overflowing call to snprintf

### DIFF
--- a/.github/workflows/build-rootfs.yml
+++ b/.github/workflows/build-rootfs.yml
@@ -3,6 +3,7 @@
 name: z-wave-protocol-controller Build in rootfs for arch
 
 on:  # yamllint disable-line rule:truthy
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   push:
     tags:
       - '*'
@@ -18,6 +19,9 @@ jobs:
           - arm64
           # - armhf # TODO Enable when supported
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@
 name: build
 
 on:  # yamllint disable-line rule:truthy
+  pull_request:
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   push:
 
 jobs:
@@ -16,6 +18,9 @@ jobs:
       project-name: z-wave-protocol-controller  # Align to docker (lowercase)
     runs-on: ubuntu-22.04
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ name: test
 run-name: "test: ${{ github.event.workflow_run.head_branch }}#${{ github.event.workflow_run.head_commit.id }}"
 
 on:  # yamllint disable-line rule:truthy
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   workflow_run:
     workflows: ["build"]
     types:
@@ -25,6 +26,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       - name: Download image
         # yamllint disable-line rule:line-length
         uses: ishworkh/container-image-artifact-download@ccb3671db007622e886a2d7037eb62b119d5ffaf  # v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   test:
     permissions:
+      actions: read
       contents: read
       statuses: write
     env:
@@ -30,7 +31,6 @@ jobs:
         with:
           image: "${{ env.project-name }}:latest"
           workflow: "build"
-          token: ${{ secrets.GH_SL_ACCESS_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
 
       # yamllint disable-line rule:line-length

--- a/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_callbacks.c
+++ b/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_callbacks.c
@@ -305,12 +305,21 @@ void zwapi_demo_zwave_api_started(const uint8_t *buffer, uint8_t buffer_length)
   char message[MAXIMUM_MESSAGE_SIZE];
   uint8_t index = 0;
 
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "Z-Wave API started. Current NIF: ");
+  int n = snprintf(message + index,
+                   sizeof(message) - index,
+                   "Z-Wave API started. Current NIF: ");
+  if (n < 0 || n >= (int)(sizeof(message) - index)) {
+    sl_log_error(LOG_TAG, "Buffer overflow prevented while writing message.");
+    return;
+  }
+  index += n;
   for (uint8_t i = 0; i < buffer_length; i++) {
-    index
-      += snprintf(message + index, sizeof(message) - index, "%02X ", buffer[i]);
+    n = snprintf(message + index, sizeof(message) - index, "%02X ", buffer[i]);
+    if (n < 0 || n >= (int)(sizeof(message) - index)) {
+      sl_log_error(LOG_TAG, "Buffer overflow prevented while writing message.");
+      return;
+    }
+    index += n;
   }
   sl_log_info(LOG_TAG, "%s\n", message);
 }

--- a/applications/zpc/components/zpc_utils/src/zpc_converters.c
+++ b/applications/zpc/components/zpc_utils/src/zpc_converters.c
@@ -52,7 +52,11 @@ sl_status_t zpc_converters_dsk_to_str(const zwave_dsk_t src,
   size_t index = 0;
   for (int i = 0; i < sizeof(zwave_dsk_t); i += 2) {
     int d = (src[i] << 8) | src[i + 1];
-    index += snprintf(&dst[index], dst_max_len - index, "%05i-", d);
+    int n = snprintf(&dst[index], dst_max_len - index, "%05i-", d);
+    if (n < 0 || n >= dst_max_len - index) {
+      return SL_STATUS_WOULD_OVERFLOW;
+    }
+    index += n;
   }
   // Erase the last "-"
   if (index > 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/12](https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/12)

To fix the issue, the return value of `snprintf` should be checked to ensure it does not exceed the remaining buffer size (`dst_max_len - index`). If the return value is negative or greater than or equal to the remaining space, the function should terminate early to prevent buffer overflow. This involves:
1. Capturing the return value of `snprintf` in a variable.
2. Validating the return value to ensure it is within bounds.
3. Breaking out of the loop or returning an error code if the return value is invalid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
