### PR TITLE
Potential fix for code scanning alert no. 13: Potentially overflowing call to snprintf

### DIFF
--- a/.github/workflows/build-rootfs.yml
+++ b/.github/workflows/build-rootfs.yml
@@ -3,6 +3,7 @@
 name: z-wave-protocol-controller Build in rootfs for arch
 
 on:  # yamllint disable-line rule:truthy
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   push:
     tags:
       - '*'
@@ -18,6 +19,9 @@ jobs:
           - arm64
           # - armhf # TODO Enable when supported
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@
 name: build
 
 on:  # yamllint disable-line rule:truthy
+  pull_request:
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   push:
 
 jobs:
@@ -16,6 +18,9 @@ jobs:
       project-name: z-wave-protocol-controller  # Align to docker (lowercase)
     runs-on: ubuntu-22.04
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ name: test
 run-name: "test: ${{ github.event.workflow_run.head_branch }}#${{ github.event.workflow_run.head_commit.id }}"
 
 on:  # yamllint disable-line rule:truthy
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   workflow_run:
     workflows: ["build"]
     types:
@@ -25,6 +26,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       - name: Download image
         # yamllint disable-line rule:line-length
         uses: ishworkh/container-image-artifact-download@ccb3671db007622e886a2d7037eb62b119d5ffaf  # v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   test:
     permissions:
+      actions: read
       contents: read
       statuses: write
     env:
@@ -30,7 +31,6 @@ jobs:
         with:
           image: "${{ env.project-name }}:latest"
           workflow: "build"
-          token: ${{ secrets.GH_SL_ACCESS_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
 
       # yamllint disable-line rule:line-length

--- a/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_callbacks.c
+++ b/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_callbacks.c
@@ -305,12 +305,21 @@ void zwapi_demo_zwave_api_started(const uint8_t *buffer, uint8_t buffer_length)
   char message[MAXIMUM_MESSAGE_SIZE];
   uint8_t index = 0;
 
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "Z-Wave API started. Current NIF: ");
+  int n = snprintf(message + index,
+                   sizeof(message) - index,
+                   "Z-Wave API started. Current NIF: ");
+  if (n < 0 || n >= (int)(sizeof(message) - index)) {
+    sl_log_error(LOG_TAG, "Buffer overflow prevented while writing message.");
+    return;
+  }
+  index += n;
   for (uint8_t i = 0; i < buffer_length; i++) {
-    index
-      += snprintf(message + index, sizeof(message) - index, "%02X ", buffer[i]);
+    n = snprintf(message + index, sizeof(message) - index, "%02X ", buffer[i]);
+    if (n < 0 || n >= (int)(sizeof(message) - index)) {
+      sl_log_error(LOG_TAG, "Buffer overflow prevented while writing message.");
+      return;
+    }
+    index += n;
   }
   sl_log_info(LOG_TAG, "%s\n", message);
 }

--- a/applications/zpc/components/zwave/zwave_controller/src/zwave_controller_utils.c
+++ b/applications/zpc/components/zwave/zwave_controller/src/zwave_controller_utils.c
@@ -118,22 +118,34 @@ void zwave_sl_log_nif_data(zwave_node_id_t node_id,
   char message[DEBUG_MESSAGE_BUFFER_LENGTH];
   uint16_t index = 0;
 
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "NIF from NodeID: %d",
-                    node_id);
+  int n = snprintf(message + index,
+                   sizeof(message) - index,
+                   "NIF from NodeID: %d",
+                   node_id);
+  if (n < 0 || n >= (int)(sizeof(message) - index)) {
+    break;
+  }
+  index += n;
 
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    " Capability/Security bytes: 0x%02X 0x%02X - ",
-                    node_info->listening_protocol,
-                    node_info->optional_protocol);
+  n = snprintf(message + index,
+               sizeof(message) - index,
+               " Capability/Security bytes: 0x%02X 0x%02X - ",
+               node_info->listening_protocol,
+               node_info->optional_protocol);
+  if (n < 0 || n >= (int)(sizeof(message) - index)) {
+    break;
+  }
+  index += n;
 
   if (node_info->optional_protocol
       & ZWAVE_NODE_INFO_OPTIONAL_PROTOCOL_CONTROLLER_MASK) {
-    index += snprintf(message + index,
-                      sizeof(message) - index,
-                      "The node is a controller - ");
+    n = snprintf(message + index,
+                 sizeof(message) - index,
+                 "The node is a controller - ");
+    if (n < 0 || n >= (int)(sizeof(message) - index)) {
+      break;
+    }
+    index += n;
   } else {
     index += snprintf(message + index,
                       sizeof(message) - index,
@@ -142,7 +154,11 @@ void zwave_sl_log_nif_data(zwave_node_id_t node_id,
 
   if (node_info->listening_protocol
       & ZWAVE_NODE_INFO_LISTENING_PROTOCOL_LISTENING_MASK) {
-    index += snprintf(message + index, sizeof(message) - index, "AL mode - ");
+    n = snprintf(message + index, sizeof(message) - index, "AL mode - ");
+    if (n < 0 || n >= (int)(sizeof(message) - index)) {
+      break;
+    }
+    index += n;
   } else if (node_info->optional_protocol
              & (ZWAVE_NODE_INFO_OPTIONAL_PROTOCOL_SENSOR_1000MS_MASK
                 | ZWAVE_NODE_INFO_OPTIONAL_PROTOCOL_SENSOR_250MS_MASK)) {
@@ -164,10 +180,14 @@ void zwave_sl_log_nif_data(zwave_node_id_t node_id,
                     node_info->specific_device_class);
 
   for (uint8_t i = 0; i < node_info->command_class_list_length; i++) {
-    index += snprintf(message + index,
-                      sizeof(message) - index,
-                      "%02X ",
-                      node_info->command_class_list[i]);
+    n = snprintf(message + index,
+                 sizeof(message) - index,
+                 "%02X ",
+                 node_info->command_class_list[i]);
+    if (n < 0 || n >= (int)(sizeof(message) - index)) {
+      break;
+    }
+    index += n;
   }
 
   sl_log_debug(LOG_TAG, "%s", message);


### PR DESCRIPTION
Potential fix for [https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/13](https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/13)

To fix the issue, we need to check the return value of each `snprintf` call. If the return value is negative (indicating an encoding error) or greater than or equal to the remaining buffer size (`sizeof(message) - index`), we should stop further writes to the buffer to prevent overflow. This involves adding conditional checks after each `snprintf` call and breaking out of the loop or function if an overflow is detected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
