### PR TITLE
Potential fix for code scanning alert no. 19: Potentially overflowing call to snprintf

### DIFF
--- a/.github/workflows/build-rootfs.yml
+++ b/.github/workflows/build-rootfs.yml
@@ -3,6 +3,7 @@
 name: z-wave-protocol-controller Build in rootfs for arch
 
 on:  # yamllint disable-line rule:truthy
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   push:
     tags:
       - '*'
@@ -18,6 +19,9 @@ jobs:
           - arm64
           # - armhf # TODO Enable when supported
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@
 name: build
 
 on:  # yamllint disable-line rule:truthy
+  pull_request:
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   push:
 
 jobs:
@@ -16,6 +18,9 @@ jobs:
       project-name: z-wave-protocol-controller  # Align to docker (lowercase)
     runs-on: ubuntu-22.04
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ name: test
 run-name: "test: ${{ github.event.workflow_run.head_branch }}#${{ github.event.workflow_run.head_commit.id }}"
 
 on:  # yamllint disable-line rule:truthy
+  # pull_request_target: # Avoid to prevent CodeQL CWE-829
   workflow_run:
     workflows: ["build"]
     types:
@@ -25,6 +26,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - name: Security check
+        if: ${{ github.event.action == 'pull_request_target'}}
+        run: echo "Prevent running (CodeQL CWE-829)" && exit 1
       - name: Download image
         # yamllint disable-line rule:line-length
         uses: ishworkh/container-image-artifact-download@ccb3671db007622e886a2d7037eb62b119d5ffaf  # v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   test:
     permissions:
+      actions: read
       contents: read
       statuses: write
     env:
@@ -30,7 +31,6 @@ jobs:
         with:
           image: "${{ env.project-name }}:latest"
           workflow: "build"
-          token: ${{ secrets.GH_SL_ACCESS_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
 
       # yamllint disable-line rule:line-length

--- a/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_callbacks.c
+++ b/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_callbacks.c
@@ -305,12 +305,21 @@ void zwapi_demo_zwave_api_started(const uint8_t *buffer, uint8_t buffer_length)
   char message[MAXIMUM_MESSAGE_SIZE];
   uint8_t index = 0;
 
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "Z-Wave API started. Current NIF: ");
+  int n = snprintf(message + index,
+                   sizeof(message) - index,
+                   "Z-Wave API started. Current NIF: ");
+  if (n < 0 || n >= (int)(sizeof(message) - index)) {
+    sl_log_error(LOG_TAG, "Buffer overflow prevented while writing message.");
+    return;
+  }
+  index += n;
   for (uint8_t i = 0; i < buffer_length; i++) {
-    index
-      += snprintf(message + index, sizeof(message) - index, "%02X ", buffer[i]);
+    n = snprintf(message + index, sizeof(message) - index, "%02X ", buffer[i]);
+    if (n < 0 || n >= (int)(sizeof(message) - index)) {
+      sl_log_error(LOG_TAG, "Buffer overflow prevented while writing message.");
+      return;
+    }
+    index += n;
   }
   sl_log_info(LOG_TAG, "%s\n", message);
 }

--- a/applications/zpc/components/zwave_api/src/zwapi_connection.c
+++ b/applications/zpc/components/zwave_api/src/zwapi_connection.c
@@ -50,14 +50,37 @@ static const char *zwapi_frame_to_string(const uint8_t *buffer,
       // Don't log the SOF byte.
       continue;
     } else if (i == 1) {
-      index += snprintf(message + index, sizeof(message) - index, "Length=");
+      {
+        int n = snprintf(message + index, sizeof(message) - index, "Length=");
+        if (n < 0 || n >= sizeof(message) - index) {
+          break;
+        }
+        index += n;
+      }
     } else if (i == 2) {
-      index += snprintf(message + index, sizeof(message) - index, "Type=");
+      {
+        int n = snprintf(message + index, sizeof(message) - index, "Type=");
+        if (n < 0 || n >= sizeof(message) - index) {
+          break;
+        }
+        index += n;
+      }
     } else if (i == 3) {
-      index += snprintf(message + index, sizeof(message) - index, "Cmd=");
+      {
+        int n = snprintf(message + index, sizeof(message) - index, "Cmd=");
+        if (n < 0 || n >= sizeof(message) - index) {
+          break;
+        }
+        index += n;
+      }
     }
-    index
-      += snprintf(message + index, sizeof(message) - index, "%02X ", buffer[i]);
+    {
+      int n = snprintf(message + index, sizeof(message) - index, "%02X ", buffer[i]);
+      if (n < 0 || n >= sizeof(message) - index) {
+        break;
+      }
+      index += n;
+    }
   }
   return message;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/19](https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/19)

To fix the issue, we need to validate the return value of `snprintf` after each call. If the return value is negative or exceeds the remaining buffer size, we should stop further writes to prevent buffer overflow. This involves:
1. Storing the return value of `snprintf` in a variable.
2. Checking if the return value is negative or greater than or equal to the remaining buffer size (`sizeof(message) - index`).
3. Breaking out of the loop or handling the error appropriately if the condition is met.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
