### PR TITLE
Potential fix for code scanning alert no. 8: Potentially overflowing call to snprintf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download image
+        id: image
         # yamllint disable-line rule:line-length
         uses: ishworkh/container-image-artifact-download@ccb3671db007622e886a2d7037eb62b119d5ffaf  # v2.0.0
         with:
@@ -32,7 +33,18 @@ jobs:
           workflow: "build"
           token: ${{ secrets.GH_SL_ACCESS_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
-
+      - name: Check and remove downloaded artifact
+        # yamllint disable rule:line-length
+        run: |
+          set -xe
+          file="/tmp/action_image_artifact_${{ github.event.repository.name }}_latest/${{ github.event.repository.name }}_latest"
+          echo "Info for comparing to build artifacts"
+          sha256sum "${file}"
+          tar -xOf "${file}" manifest.json | jq
+          echo "TODO: https://github.com/ishworkh/container-image-artifact-download/issues/7#issuecomment-2904751460"
+          rm -rfv "${file}"
+          echo "TODO: https://docs.docker.com/engine/security/trust/"
+        # yamllint enable rule:line-length
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -59,14 +71,15 @@ jobs:
           ${{ env.debian_packages }}
           && sudo apt-get clean -y
           && echo "https://github.com/Z-Wave-Alliance/z-wave-stack/issues/733"
-          && mkdir -p z-wave-stack-binaries
+          && mkdir -p ${{ runner.temp }}/z-wave-stack-binaries
           && tar xfz z-wave-stack-binaries-*-Linux.tar.gz
-          -C z-wave-stack-binaries
+          -C ${{ runner.temp }}/z-wave-stack-binaries
           && rm z-wave-stack-binaries-*-Linux.tar.gz
           && date -u
 
       - name: Run
         id: run
+        # yamllint disable rule:line-length
         run: |
           set -x
           export ZPC_RUN_MODE="docker"
@@ -74,9 +87,10 @@ jobs:
           $ZPC_COMMAND --version
           docker-compose pull
           export ZPC_COMMAND="docker-compose up --abort-on-container-exit"
-          cd z-wave-stack-binaries/bin && file -E *_x86_REALTIME.elf && cd -
+          export z_wave_stack_binaries_bin_dir="${{ runner.temp }}/z-wave-stack-binaries/bin"
           export ZPC_ARGS="--log.level=d"
           ./scripts/tests/z-wave-stack-binaries-test.sh
+        # yamllint enable rule:line-length
         continue-on-error: true
 
       - name: Propagate run status to commit status

--- a/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_callbacks.c
+++ b/applications/zpc/applications/zwave_api_demo/src/zwave_api_demo_callbacks.c
@@ -26,30 +26,42 @@ void zwapi_demo_application_handler(uint8_t rx_status,
   char message[MAXIMUM_MESSAGE_SIZE];
   uint16_t index = 0;
 
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "Z-Wave Command received: ");
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "rx_status: %d - ",
-                    rx_status);
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "destination NodeID: %d - ",
-                    destination_node_id);
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "source NodeID: %d - ",
-                    source_node_id);
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "RSSI value: %d - Payload: ",
-                    rssi_value);
+  int n = snprintf(message + index,
+                   sizeof(message) - index,
+                   "Z-Wave Command received: ");
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
+  n = snprintf(message + index,
+               sizeof(message) - index,
+               "rx_status: %d - ",
+               rx_status);
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
+  n = snprintf(message + index,
+               sizeof(message) - index,
+               "destination NodeID: %d - ",
+               destination_node_id);
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
+  n = snprintf(message + index,
+               sizeof(message) - index,
+               "source NodeID: %d - ",
+               source_node_id);
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
+  n = snprintf(message + index,
+               sizeof(message) - index,
+               "RSSI value: %d - Payload: ",
+               rssi_value);
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
   for (uint8_t i = 0; i < zwave_command_length; i++) {
-    index += snprintf(message + index,
-                      sizeof(message) - index,
-                      "%02X ",
-                      zwave_command[i]);
+    n = snprintf(message + index,
+                 sizeof(message) - index,
+                 "%02X ",
+                 zwave_command[i]);
+    if (n < 0 || n >= sizeof(message) - index) break;
+    index += n;
   }
   sl_log_debug(LOG_TAG, "%s\n", message);
 }
@@ -64,28 +76,37 @@ void zwapi_demo_application_controller_update(uint8_t status,
   char message[MAXIMUM_MESSAGE_SIZE];
   uint16_t index = 0;
 
-  index += snprintf(message + index, sizeof(message) - index, "NIF received: ");
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "status: %d - ",
-                    status);
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "NodeID: %d - ",
-                    node_id);
-
-  index += snprintf(message + index,
-                    sizeof(message) - index,
-                    "NWI HomeID: %X - ",
-                    nwi_home_id);
-
-  index += snprintf(message + index, sizeof(message) - index, "NIF Contents:");
-
+  int n = snprintf(message + index, sizeof(message) - index, "NIF received: ");
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
+  n = snprintf(message + index,
+               sizeof(message) - index,
+               "status: %d - ",
+               status);
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
+  n = snprintf(message + index,
+               sizeof(message) - index,
+               "NodeID: %d - ",
+               node_id);
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
+  n = snprintf(message + index,
+               sizeof(message) - index,
+               "NWI HomeID: %X - ",
+               nwi_home_id);
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
+  n = snprintf(message + index, sizeof(message) - index, "NIF Contents:");
+  if (n < 0 || n >= sizeof(message) - index) return;
+  index += n;
   for (uint8_t i = 0; i < zwave_nif_length; i++) {
-    index += snprintf(message + index,
-                      sizeof(message) - index,
-                      "%02X ",
-                      zwave_nif[i]);
+    n = snprintf(message + index,
+                 sizeof(message) - index,
+                 "%02X ",
+                 zwave_nif[i]);
+    if (n < 0 || n >= sizeof(message) - index) break;
+    index += n;
   }
   sl_log_debug(LOG_TAG, "%s\n", message);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/8](https://github.com/rzr/z-wave-protocol-controller/security/code-scanning/8)

To fix the issue, we need to validate the return value of each `snprintf` call. If the return value is negative (indicating an encoding error) or greater than or equal to the remaining buffer size, we should stop appending to the buffer to prevent overflow. This involves:
1. Storing the return value of `snprintf` in a variable.
2. Checking if the return value is valid and within bounds.
3. Breaking out of the loop or skipping further `snprintf` calls if the buffer is full or an error occurs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
